### PR TITLE
Allow sending the coordinates of gravestones to players

### DIFF
--- a/src/main/java/net/guavy/gravestones/Gravestones.java
+++ b/src/main/java/net/guavy/gravestones/Gravestones.java
@@ -24,6 +24,7 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemGroup;
 import net.minecraft.item.ItemStack;
 import net.minecraft.state.property.Properties;
+import net.minecraft.text.TranslatableText;
 import net.minecraft.util.collection.DefaultedList;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.BlockPos;
@@ -112,7 +113,12 @@ public class Gravestones implements ModInitializer {
 
 				gravestoneBlockEntity.sync();
 				block.onBreak(world, blockPos, blockState, player);
+
+				if (GravestonesConfig.getConfig().mainSettings.sendGraveCoordinates) {
+					player.sendMessage(new TranslatableText("text.gravestones.grave_coordinates", gravePos.getX(), gravePos.getY(), gravePos.getZ()), false);
+				}
 				System.out.println("[Gravestones] Gravestone spawned at: " + gravePos.getX() + ", " + gravePos.getY() + ", " + gravePos.getZ());
+
 				break;
 			}
 		}

--- a/src/main/java/net/guavy/gravestones/config/GravestonesConfig.java
+++ b/src/main/java/net/guavy/gravestones/config/GravestonesConfig.java
@@ -27,6 +27,9 @@ public class GravestonesConfig implements ConfigData {
         public boolean enableGraveLooting = false;
 
         @ConfigEntry.Gui.Tooltip
+        public boolean sendGraveCoordinates = false;
+
+        @ConfigEntry.Gui.Tooltip
         public int minimumOpLevelToLoot = 4;
 
         @ConfigEntry.Gui.Tooltip

--- a/src/main/resources/assets/gravestones/lang/en_us.json
+++ b/src/main/resources/assets/gravestones/lang/en_us.json
@@ -10,6 +10,10 @@
   "text.autoconfig.gravestones.option.mainSettings.enableGraveLooting": "Enable Gravestone Looting",
   "text.autoconfig.gravestones.option.mainSettings.enableGraveLooting.@Tooltip": "Whether other players should be able to retrieve a player's gravestone.",
 
+  "text.autoconfig.gravestones.option.mainSettings.sendGraveCoordinates": "Send Gravestone Coordinates",
+  "text.autoconfig.gravestones.option.mainSettings.sendGraveCoordinates.@Tooltip": "Whether the player should be sent the coordinates of their gravestone upon death.",
+  "text.gravestones.grave_coordinates": "Your gravestone has spawned at [x: %d, y: %d, z: %d]",
+
   "text.autoconfig.gravestones.option.mainSettings.minimumOpLevelToLoot": "Minimum bypass OP Level",
   "text.autoconfig.gravestones.option.mainSettings.minimumOpLevelToLoot.@Tooltip": "The minumum OP level a player has to be to bypass gravestone world protection",
 


### PR DESCRIPTION
This pull request adds a new configuration option, `sendGraveCoordinates`. When enabled, players will receive the coordinates of their gravestone when it is spawned.