### PR TITLE
Added Gravestone block to dragon_immune.json

### DIFF
--- a/src/main/resources/data/minecraft/tags/blocks/dragon_immune.json
+++ b/src/main/resources/data/minecraft/tags/blocks/dragon_immune.json
@@ -1,0 +1,22 @@
+{
+  "replace": true,
+  "values": [
+    "minecraft:barrier",
+    "minecraft:bedrock",
+    "minecraft:end_portal",
+    "minecraft:end_portal_frame",
+    "minecraft:end_gateway",
+    "minecraft:command_block",
+    "minecraft:repeating_command_block",
+    "minecraft:chain_command_block",
+    "minecraft:structure_block",
+    "minecraft:jigsaw",
+    "minecraft:moving_piston",
+    "minecraft:obsidian",
+    "minecraft:crying_obsidian",
+    "minecraft:end_stone",
+    "minecraft:iron_bars",
+    "minecraft:respawn_anchor",
+    "gravestones:gravestone"
+  ]
+}


### PR DESCRIPTION
This will make Gravestone immune to the Ender Dragon by default.
Alternative to https://github.com/Geometrically/Gravestones/pull/28  which enables immunity by config.
(Sorry I'm new to Github so I might make mistakes with the PRs and commits.)