### PR TITLE
Fixed a bug when custom player inventories get deleted when retrieving a grave by adding a `GravestonesApi#getInventory(...)`` call to GravestoneBlock#RetrieveGrave.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ yarn_mappings=1.16.2+build.47
 loader_version=0.9.3+build.207
 
 # Mod Properties
-mod_version = v1.9
+mod_version = v1.10
 maven_group = net.guavy
 archives_base_name = gravestones
 

--- a/src/main/java/net/guavy/gravestones/block/GravestoneBlock.java
+++ b/src/main/java/net/guavy/gravestones/block/GravestoneBlock.java
@@ -108,6 +108,10 @@ public class GravestoneBlock extends HorizontalFacingBlock implements BlockEntit
         retrievalInventory.addAll(playerEntity.inventory.armor);
         retrievalInventory.addAll(playerEntity.inventory.offHand);
 
+        for (GravestonesApi gravestonesApi : Gravestones.apiMods) {
+            retrievalInventory.addAll(gravestonesApi.getInventory(playerEntity));
+        }
+
         playerEntity.inventory.clear();
 
         if(GravestonesConfig.getConfig().mainSettings.dropType == GravestoneDropType.PUT_IN_INVENTORY) {
@@ -145,6 +149,8 @@ public class GravestoneBlock extends HorizontalFacingBlock implements BlockEntit
                 extraItems.add(retrievalInventory.get(40));
 
             extraItems.addAll(retrievalInventory.subList(0, 36));
+            if (retrievalInventory.size() > 41)
+                extraItems.addAll(retrievalInventory.subList(41, retrievalInventory.size()));
 
             List<Integer> openSlots = getInventoryOpenSlots(playerEntity.inventory.main);
 


### PR DESCRIPTION
Discovered while making this mod compatible with [Inventorio](https://github.com/Lizard-Of-Oz/Inventorio). [Associated Inventorio issue](https://github.com/Lizard-Of-Oz/Inventorio/issues/19)